### PR TITLE
Fix 404 setup

### DIFF
--- a/lib/pages/getStaticProps/setup.js
+++ b/lib/pages/getStaticProps/setup.js
@@ -23,7 +23,11 @@ const setup = () => {
 
     // Copy pre-rendered HTML page
     const htmlPath = getFilePathForRoute(route, "html");
-    setupStaticFileForPage(htmlPath, `${route}/index.html`);
+    if (htmlPath === '/404.html') {
+      setupStaticFileForPage(htmlPath);
+    } else {
+      setupStaticFileForPage(htmlPath, `${route}/index.html`);
+    }
 
     // Copy page's JSON data
     const jsonPath = getFilePathForRoute(route, "json");


### PR DESCRIPTION
I noticed our 404s  are kind of broken, e.g. compare https://www.sleepingduck.website/some/bad/page to this old deploy https://5fa1d97ce7699100079b31b1--sleepingduck.netlify.app/some/bad/page.

Most pages like `something.html` are now output as `something/index.html` to make trailing slashes work properly. To use a custom 404 page though Netlify expects `404.html` to be at the top level, so this commit adds an exception so that we output `404.html` instead of `404/index.html`.

Once this is up we can update the website repo and see if Netlify actually pick up the `404.html` file as expected.
